### PR TITLE
Add depedency in package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   geometry_msgs
 )
-find_package(OpenCV 2 REQUIRED core highgui)
+find_package(OpenCV REQUIRED core highgui)
 
 catkin_package(
 )

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,9 @@
   <build_depend>roscpp</build_depend>
   <run_depend>roscpp</run_depend>
 
+  <build_depend>yaml-cpp</build_depend>
+  <build_depend>libusb-1.0-dev</build_depend>
+
   <export>
   </export>
 </package>


### PR DESCRIPTION
Add the dependency in package.xml, which helps us to download the dependency from 'rosdep install'.